### PR TITLE
Remove RCTSparseArray

### DIFF
--- a/ToolTipMenu/ToolTipMenu.m
+++ b/ToolTipMenu/ToolTipMenu.m
@@ -2,7 +2,6 @@
 
 #import "RCTBridge.h"
 #import "RCTToolTipText.h"
-#import "RCTSparseArray.h"
 #import "RCTUIManager.h"
 
 @implementation ToolTipMenu


### PR DESCRIPTION
`RCTSparseArray` was replaced by `NSDictionary` but it does not seem to be needed here.
