### PR TITLE
Updated styling of the tooltip inner TouchableHighlight to fill the size of the tooltip container

### DIFF
--- a/ToolTip.ios.js
+++ b/ToolTip.ios.js
@@ -70,7 +70,7 @@ var ViewClass = React.createClass({
 
   render: function() {
     return (
-      <RCTToolTipText ref='toolTipText' onChange={this.handleToolTipTextChange} style={this.props.style}>>
+      <RCTToolTipText ref='toolTipText' onChange={this.handleToolTipTextChange} style={this.props.style}>
         <TouchableHighlight
           {...this.getTouchableHighlightProps()}
         >

--- a/ToolTip.ios.js
+++ b/ToolTip.ios.js
@@ -50,6 +50,12 @@ var ViewClass = React.createClass({
     } else {
       props.onPress = this.showMenu;
     }
+	
+	// Override the style for the touchable highlight to fill the size of the tooltip container.
+    props.style = {
+        flex: 1,
+        alignSelf: 'stretch'
+    };
 
     return props;
   },
@@ -64,7 +70,7 @@ var ViewClass = React.createClass({
 
   render: function() {
     return (
-      <RCTToolTipText ref='toolTipText' onChange={this.handleToolTipTextChange}>
+      <RCTToolTipText ref='toolTipText' onChange={this.handleToolTipTextChange} style={this.props.style}>>
         <TouchableHighlight
           {...this.getTouchableHighlightProps()}
         >


### PR DESCRIPTION
Otherwise, any content that is wrapped by a tooltip wouldn't flow properly in a flex layout.
