### PR TITLE
introduce a new method to show tooltip with coordinates

### DIFF
--- a/ToolTip.ios.js
+++ b/ToolTip.ios.js
@@ -25,6 +25,10 @@ var ViewClass = React.createClass({
     ToolTipMenu.show(findNodeHandle(this.refs.toolTipText), this.getOptionTexts());
   },
 
+  showMenuFromRect: function(x, y, w, h) {
+    ToolTipMenu.showFromRect(findNodeHandle(this.refs.toolTipText), this.getOptionTexts(), [x, y, w, h]);
+  },
+
   getOptionTexts: function() {
     return this.props.actions.map((option) => option.text);
   },

--- a/ToolTipMenu/ToolTipMenu.m
+++ b/ToolTipMenu/ToolTipMenu.m
@@ -35,4 +35,28 @@ RCT_EXPORT_METHOD(show:(nonnull NSNumber *)reactTag
     [menuCont setMenuVisible:YES animated:YES];
 }
 
+RCT_EXPORT_METHOD(showFromRect:(nonnull NSNumber *)reactTag
+                  items: (NSArray *)items
+                  rect: (NSArray *)rectArr)
+{
+    CGRect rect = CGRectMake([rectArr[0] floatValue], [rectArr[1] floatValue],
+                             [rectArr[2] floatValue], [rectArr[3] floatValue]);
+    UIView *view = [self.bridge.uiManager viewForReactTag:reactTag];
+    NSArray *buttons = items;
+    NSMutableArray *menuItems = [NSMutableArray array];
+    for (NSString *buttonText in buttons) {
+        NSString *sel = [NSString stringWithFormat:@"magic_%@", buttonText];
+        [menuItems addObject:[[UIMenuItem alloc]
+                              initWithTitle:buttonText
+                              action:NSSelectorFromString(sel)]];
+    }
+    [view becomeFirstResponder];
+    UIMenuController *menuCont = [UIMenuController sharedMenuController];
+    view.superview.frame = rect;
+    [menuCont setTargetRect:view.frame inView:view.superview];
+    menuCont.arrowDirection = UIMenuControllerArrowDown;
+    menuCont.menuItems = menuItems;
+    [menuCont setMenuVisible:YES animated:YES];
+}
+
 @end


### PR DESCRIPTION
Hi @chirag04 

I'm facing a very tricky problem when I'm using tooltip with redux. I have to call `show` method during `componentDidUpdate` stage, but by the time, container view of tooltip would still be in the wrong position. So I add a method to put the container to right place before it gets rendered.

More specifically, I form my view like this

```
        <WebView>
            <View pointerEvents="none" style={ {
                position: 'absolute',
                top: this.props.targetPosition.clickY,
                left: this.props.targetPosition.clickX,
                width: 1,
                height: 1,
              } }>
              <ToolTip
                ref="theToolTip"
                actions={ this.props.toolTipActions }
                underlayColor='transparent'
                disabled={ true }
                style={ styles.toolTip } />
            </View>
        </WebView>
```

So the flow is, 
-> someone clicks `WebView`, it tells component where to show the tooltip 
-> reducer changes coordinates in states, also map to props
-> `componentDidUpdate` state: WebView gets new coordinates, call `showMenu`
-> re-render, apply the new coordinates to the `View`

What's tricky is when it's in the stage of `componentDidUpdate`, `View` has not re-rended yet, so the tooltip shows from old coordinates. Also there's no callback to allow me to do anything (like calling `showMenu`) after view got re-rendered.

So I expose a new method here to show the tooltip with coordinate, called `showFromRect`, and I change the container to where it should be. Of course when app runs into render stage it will update the coordinate of the container again, but as long as we passed same coordinates before that, it will remain same position.

Might be too specific, hope someone else would want this too :)
