### PR TITLE
Add support for UIMenuControllerArrowDefault

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A react-native component from displaying tooltip. Uses UIMenuController.
 
 - `actions`: Array of actions `[{text: 'Copy', onPress: () => Clipboard.set(this.someValue) }]`
 - `longPress`: Boolean indicating if the tooltip should be showing on longPress, false by default.
-- `arrowDirection`: String indicating the direction of the tooltip arrow. Possible values are: `up`, `down`, `left`, and `right`. Default is `down`.
+- `arrowDirection`: String indicating the direction of the tooltip arrow. Possible values are: `up`, `down`, `left`, `right`, and `default`. Default is `default`, which means to point up or down at the object of focus based on its location on the screen.
 
 #### Props from TouchableHighlight.propTypes
 

--- a/ToolTip.ios.js
+++ b/ToolTip.ios.js
@@ -19,7 +19,7 @@ export default class ToolTip extends PureComponent {
             text: PropTypes.string.isRequired,
             onPress: PropTypes.func
         })),
-        arrowDirection: PropTypes.oneOf(['up', 'down', 'left', 'right']),
+        arrowDirection: PropTypes.oneOf(['up', 'down', 'left', 'right', 'default']),
         longPress: PropTypes.bool,
         onHide: PropTypes.func,
         onShow: PropTypes.func,
@@ -27,7 +27,7 @@ export default class ToolTip extends PureComponent {
     };
 
     static defaultProps = {
-        arrowDirection: 'down',
+        arrowDirection: 'default',
         onHide: () => true,
         onShow: () => true
     };

--- a/ToolTipMenu/ToolTipMenu.m
+++ b/ToolTipMenu/ToolTipMenu.m
@@ -35,12 +35,14 @@ RCT_EXPORT_METHOD(show:(nonnull NSNumber *)reactTag
 
     if([arrowDirection isEqualToString: @"up"]){
       menuCont.arrowDirection = UIMenuControllerArrowUp;
-    }else if ([arrowDirection isEqualToString: @"right"]){
+    } else if ([arrowDirection isEqualToString: @"right"]){
       menuCont.arrowDirection = UIMenuControllerArrowRight;
-    }else if ([arrowDirection isEqualToString: @"left"]) {
+    } else if ([arrowDirection isEqualToString: @"left"]) {
       menuCont.arrowDirection = UIMenuControllerArrowLeft;
-    } else {
+    } else if ([arrowDirection isEqualToString: @"down"]) {
       menuCont.arrowDirection = UIMenuControllerArrowDown;
+    } else {
+      menuCont.arrowDirection = UIMenuControllerArrowDefault;   
     }
     menuCont.menuItems = menuItems;
     [menuCont setMenuVisible:YES animated:YES];


### PR DESCRIPTION
This will allow for giving iOS control over what direction to show the `UIMenuController`, considering it's location on the screen.

From https://developer.apple.com/documentation/uikit/uimenucontroller/1622821-arrowdirection:
> The default behavior (`UIMenuControllerArrowDefault`) is to point up or down at the object of focus based on its location on the screen.